### PR TITLE
Bugfix nov 18 spec_onshore

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Run simulations with this Streamlit App
 - https://github.com/GokuMohandas/mlops-course
 
 # Future Ideas:
+- [x] It would be useful to add a column in the simulation table for the specific amount you can to onshore or offshore, otherwise you lose that information if you add more than one simation to the table.
 - Fetch XHV price via https://github.com/man-c/pycoingecko
 
 # Donations:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(Path(BASE_DIR, "requirements.txt"), "r") as file:
 # Define our package
 setup(
     name="vault-backed-shoring",
-    version="0.3.2",
+    version="0.3.3",
     description="Calculates (On/Off)Shore for Haven Protocol 3.0",
     author="Reed Schimmel",
     author_email="reed+vbs@simplelogin.com",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -10,7 +10,7 @@ def convert_df(df):
     # IMPORTANT: Cache the conversion to prevent computation on every rerun
     return df.to_csv().encode('utf-8')
 
-APP_VERSION = "0.3.2" # TODO: grab this from setup.py or whatever https://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package
+APP_VERSION = "0.3.3" # TODO: grab this from setup.py or whatever https://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package
 PROPOSAL_VERSION = 4
 # TESTING = True
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import streamlit as st
 
@@ -90,6 +91,7 @@ with col1a:
             xassets_mcap=xassets_mcap,
             static_parameters=st.session_state['static_parameters'],
         )
+        sim[f"{shore_unit} to {shore_type.lower()}"] = np.nan if is_max else amount_to_shore
 
         st.session_state['simulation_list'].append(sim)
 

--- a/vault_backed_shoring/onshore.py
+++ b/vault_backed_shoring/onshore.py
@@ -66,14 +66,14 @@ def specific_onshore(
         'Spread VBS': 0,
         'Slippage VBS': 0,
         'Total VBS': 0,
-        'Max Offshore XHV': 0,
-        'Max Onshore xUSD': 0,
+        'Max Offshore XHV': np.nan,
+        'Max Onshore xUSD': np.nan,
         'Collateral Needed (XHV)': 0,
         'Error Message': np.nan,
     }
 
 
-    if (not ignore_errors) and amount_to_onshore_xhv > xusd_vault:
+    if (not ignore_errors) and xusd_to_onshore > xusd_vault:
         results['Error Message'] = 'not enough xUSD available to onshore'
         return results
     if (not ignore_errors) and amount_to_onshore_xhv < static_parameters['min_shore_amount']:


### PR DESCRIPTION
- Fixes `not enough xUSD available to onshore` error when there is enough xUSD.
- Adds a column in the simulation table for the specific amount you can to onshore or offshore, otherwise you lose that information if you add more than one simation to the table.